### PR TITLE
Fix protocol issue during startup

### DIFF
--- a/mcp/protocol/src/main/scala/ch/linkyard/mcp/protocol/lifecycle.scala
+++ b/mcp/protocol/src/main/scala/ch/linkyard/mcp/protocol/lifecycle.scala
@@ -143,7 +143,7 @@ object Initialize:
       }
 
       given Decoder[Changable] = Decoder.instance { c =>
-        c.downField("listChanged").as[Boolean].map(Changable.apply)
+        c.downField("listChanged").as[Option[Boolean]].map(_.getOrElse(false)).map(Changable.apply)
       }
 
     case class Subscribable(subscribe: Boolean, listChanged: Boolean)


### PR DESCRIPTION
Great library! I am super excited to start making use of it. I did run into a problem that I was able to fix here that works locally. _Claude Code_ does not always send the `listChanged` field during the handshake. This can prevent a server built with this library to fail during startup. I made this field optional and defaulted to `false`.

Here is the original error from _Claude Code_:
```
[DEBUG] MCP server "deckbuilder-mcp-shell": Connection failed after 521ms: MCP error -32700: DecodingFailure at .capabilities.roots.listChanged: Missing required field
```
